### PR TITLE
Remove dependency of redo when trying to configure

### DIFF
--- a/ninja_configure.do
+++ b/ninja_configure.do
@@ -8,8 +8,8 @@ for m in $(cat plugins.list); do echo "$PD/$m/files.list"; done | xargs redo-ifc
 mkdir -p $BUILD_DIR/debug
 mkdir -p $BUILD_DIR/release
 
-CFLAGS="-Og -g" ./ninja_generate > $BUILD_DIR/debug/build.ninja
-CFLAGS="-O2" ./ninja_generate > $BUILD_DIR/release/build.ninja
+PD=$PD ID=$ID INSTALL_DIR=$INSTALL_DIR CFLAGS="-Og -g" ./ninja_generate > $BUILD_DIR/debug/build.ninja
+PD=$PD ID=$ID INSTALL_DIR=$INSTALL_DIR CFLAGS="-O2" ./ninja_generate > $BUILD_DIR/release/build.ninja
 
 redo-ifchange $BUILD_DIR/debug/build.ninja
 redo-ifchange $BUILD_DIR/release/build.ninja

--- a/ninja_generate
+++ b/ninja_generate
@@ -6,8 +6,6 @@
 # for loops avoid creating a subshell
 # shellcheck disable=SC2013
 
-. ./envrc
-
 cat << EOF
 pd = $PD
 cflags = $CFLAGS -Wall -Wextra -std=c++2b -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -Werror=format-security


### PR DESCRIPTION
That way someone can call ninja_generate even without ```redo``` installed. Just need to send the right info to it